### PR TITLE
Add Interactive Example FM API Program

### DIFF
--- a/examples/cxl-mctp.c
+++ b/examples/cxl-mctp.c
@@ -2,29 +2,8 @@
 /*
  * This file is part of libcxlmi.
  */
-#include <stdio.h>
-#include <stdlib.h>
-#include <stdint.h>
-#include <unistd.h>
-#include <string.h>
-#include <assert.h>
-
 #include <libcxlmi.h>
-
-typedef enum CxlExtentSelectionPolicy {
-    CXL_EXTENT_SELECTION_POLICY_FREE,
-    CXL_EXTENT_SELECTION_POLICY_CONTIGUOUS,
-    CXL_EXTENT_SELECTION_POLICY_PRESCRIPTIVE,
-    CXL_EXTENT_SELECTION_POLICY_ENABLE_SHARED_ACCESS,
-    CXL_EXTENT_SELECTION_POLICY__MAX,
-} CxlExtentSelectionPolicy;
-
-typedef enum CxlExtentRemovalPolicy {
-    CXL_EXTENT_REMOVAL_POLICY_TAG_BASED,
-    CXL_EXTENT_REMOVAL_POLICY_PRESCRIPTIVE,
-    CXL_EXTENT_REMOVAL_POLICY__MAX,
-} CxlExtentRemovalPolicy;
-
+#include "examples.h"
 
 static int show_dc_extents(struct cxlmi_endpoint *ep);
 
@@ -392,62 +371,6 @@ free_out:
 	return rc;
 }
 
-static const uint8_t cel_uuid[0x10] = { 0x0d, 0xa9, 0xc0, 0xb5,
-					0xbf, 0x41,
-					0x4b, 0x78,
-					0x8f, 0x79,
-					0x96, 0xb1, 0x62, 0x3b, 0x3f, 0x17 };
-
-static const uint8_t ven_dbg[0x10] = { 0x5e, 0x18, 0x19, 0xd9,
-				       0x11, 0xa9,
-				       0x40, 0x0c,
-				       0x81, 0x1f,
-				       0xd6, 0x07, 0x19, 0x40, 0x3d, 0x86 };
-
-static const uint8_t c_s_dump[0x10] = { 0xb3, 0xfa, 0xb4, 0xcf,
-					0x01, 0xb6,
-					0x43, 0x32,
-					0x94, 0x3e,
-					0x5e, 0x99, 0x62, 0xf2, 0x35, 0x67 };
-
-static const int maxlogs = 10; /* Only 7 in CXL r3.1, but let us leave room */
-static int parse_supported_logs(struct cxlmi_cmd_get_supported_logs *pl,
-				size_t *cel_size)
-{
-	int i, j;
-
-	*cel_size = 0;
-	printf("Get Supported Logs Response %d\n",
-	       pl->num_supported_log_entries);
-
-	for (i = 0; i < pl->num_supported_log_entries; i++) {
-		for (j = 0; j < sizeof(pl->entries[i].uuid); j++) {
-			if (pl->entries[i].uuid[j] != cel_uuid[j])
-				break;
-		}
-		if (j == 0x10) {
-			*cel_size = pl->entries[i].log_size;
-			printf("\tCommand Effects Log (CEL) available\n");
-		}
-		for (j = 0; j < sizeof(pl->entries[i].uuid); j++) {
-			if (pl->entries[i].uuid[j] != ven_dbg[j])
-				break;
-		}
-		if (j == 0x10)
-			printf("\tVendor Debug Log available\n");
-		for (j = 0; j < sizeof(pl->entries[i].uuid); j++) {
-			if (pl->entries[i].uuid[j] != c_s_dump[j])
-				break;
-		}
-		if (j == 0x10)
-			printf("\tComponent State Dump Log available\n");
-	}
-	if (cel_size == 0) {
-		return -1;
-	}
-	return 0;
-}
-
 static int show_cel(struct cxlmi_endpoint *ep, int cel_size)
 {
 	struct cxlmi_cmd_get_log_req in = {
@@ -481,63 +404,6 @@ static int show_cel(struct cxlmi_endpoint *ep, int cel_size)
 done:
 	free(ret);
 	return rc;
-}
-
-static int support_opcode(struct cxlmi_endpoint *ep, int cel_size,
-		uint16_t opcode, bool *supported)
-{
-	struct cxlmi_cmd_get_log_req in = {
-		.offset = 0,
-		.length = cel_size,
-	};
-	struct cxlmi_cmd_get_log_cel_rsp *ret;
-	int i, rc;
-
-	ret = calloc(1, sizeof(*ret) + cel_size);
-	if (!ret)
-		return -1;
-
-	memcpy(in.uuid, cel_uuid, sizeof(in.uuid));
-	rc = cxlmi_cmd_get_log_cel(ep, NULL, &in, ret);
-	if (rc)
-		goto done;
-
-	for (i = 0; i < cel_size / sizeof(*ret); i++) {
-		if (opcode == ret[i].opcode) {
-			*supported = true;
-			break;
-		}
-	}
-done:
-	free(ret);
-	return rc;
-}
-
-static bool ep_supports_op(struct cxlmi_endpoint *ep, uint16_t opcode)
-{
-	int rc;
-	size_t cel_size;
-	struct cxlmi_cmd_get_supported_logs *gsl;
-	bool op_support = false;
-
-	gsl = calloc(1, sizeof(*gsl) + maxlogs * sizeof(*gsl->entries));
-	if (!gsl)
-		return op_support;
-
-	rc = cxlmi_cmd_get_supported_logs(ep, NULL, gsl);
-	if (rc)
-		return op_support;
-
-	rc = parse_supported_logs(gsl, &cel_size);
-	if (rc)
-		return op_support;
-	else {
-		/* we know there is a CEL */
-		rc = support_opcode(ep, cel_size, opcode, &op_support);
-	}
-
-	free(gsl);
-	return op_support;
 }
 
 static int get_device_logs(struct cxlmi_endpoint *ep)

--- a/examples/examples.h
+++ b/examples/examples.h
@@ -1,0 +1,143 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <unistd.h>
+#include <string.h>
+#include <assert.h>
+
+#include <libcxlmi.h>
+
+#define MiB (1024 * 1024)
+
+const uint8_t cel_uuid[0x10] = { 0x0d, 0xa9, 0xc0, 0xb5,
+    0xbf, 0x41,
+    0x4b, 0x78,
+    0x8f, 0x79,
+    0x96, 0xb1, 0x62, 0x3b, 0x3f, 0x17 };
+
+const uint8_t ven_dbg[0x10] = { 0x5e, 0x18, 0x19, 0xd9,
+       0x11, 0xa9,
+       0x40, 0x0c,
+       0x81, 0x1f,
+       0xd6, 0x07, 0x19, 0x40, 0x3d, 0x86 };
+
+const uint8_t c_s_dump[0x10] = { 0xb3, 0xfa, 0xb4, 0xcf,
+    0x01, 0xb6,
+    0x43, 0x32,
+    0x94, 0x3e,
+    0x5e, 0x99, 0x62, 0xf2, 0x35, 0x67 };
+
+const int maxlogs = 10; /* Only 7 in CXL r3.1, but let us leave room */
+
+typedef enum CxlExtentSelectionPolicy {
+    CXL_EXTENT_SELECTION_POLICY_FREE,
+    CXL_EXTENT_SELECTION_POLICY_CONTIGUOUS,
+    CXL_EXTENT_SELECTION_POLICY_PRESCRIPTIVE,
+    CXL_EXTENT_SELECTION_POLICY_ENABLE_SHARED_ACCESS,
+    CXL_EXTENT_SELECTION_POLICY__MAX,
+} CxlExtentSelectionPolicy;
+
+typedef enum CxlExtentRemovalPolicy {
+    CXL_EXTENT_REMOVAL_POLICY_TAG_BASED,
+    CXL_EXTENT_REMOVAL_POLICY_PRESCRIPTIVE,
+    CXL_EXTENT_REMOVAL_POLICY__MAX,
+} CxlExtentRemovalPolicy;
+
+typedef struct {
+    uint64_t start_dpa;
+    uint64_t len;
+} extent;
+
+static int parse_supported_logs(struct cxlmi_cmd_get_supported_logs *pl,
+				size_t *cel_size)
+{
+	int i, j;
+
+	*cel_size = 0;
+	printf("Get Supported Logs Response %d\n",
+	       pl->num_supported_log_entries);
+
+	for (i = 0; i < pl->num_supported_log_entries; i++) {
+		for (j = 0; j < sizeof(pl->entries[i].uuid); j++) {
+			if (pl->entries[i].uuid[j] != cel_uuid[j])
+				break;
+		}
+		if (j == 0x10) {
+			*cel_size = pl->entries[i].log_size;
+			printf("\tCommand Effects Log (CEL) available\n");
+		}
+		for (j = 0; j < sizeof(pl->entries[i].uuid); j++) {
+			if (pl->entries[i].uuid[j] != ven_dbg[j])
+				break;
+		}
+		if (j == 0x10)
+			printf("\tVendor Debug Log available\n");
+		for (j = 0; j < sizeof(pl->entries[i].uuid); j++) {
+			if (pl->entries[i].uuid[j] != c_s_dump[j])
+				break;
+		}
+		if (j == 0x10)
+			printf("\tComponent State Dump Log available\n");
+	}
+	if (cel_size == 0) {
+		return -1;
+	}
+	return 0;
+}
+
+static int support_opcode(struct cxlmi_endpoint *ep, int cel_size,
+		uint16_t opcode, bool *supported)
+{
+	struct cxlmi_cmd_get_log_req in = {
+		.offset = 0,
+		.length = cel_size,
+	};
+	struct cxlmi_cmd_get_log_cel_rsp *ret;
+	int i, rc;
+
+	ret = calloc(1, sizeof(*ret) + cel_size);
+	if (!ret)
+		return -1;
+
+	memcpy(in.uuid, cel_uuid, sizeof(in.uuid));
+	rc = cxlmi_cmd_get_log_cel(ep, NULL, &in, ret);
+	if (rc)
+		goto done;
+
+	for (i = 0; i < cel_size / sizeof(*ret); i++) {
+		if (opcode == ret[i].opcode) {
+			*supported = true;
+			break;
+		}
+	}
+done:
+	free(ret);
+	return rc;
+}
+
+static bool ep_supports_op(struct cxlmi_endpoint *ep, uint16_t opcode)
+{
+	int rc;
+	size_t cel_size;
+	struct cxlmi_cmd_get_supported_logs *gsl;
+	bool op_support = false;
+
+	gsl = calloc(1, sizeof(*gsl) + maxlogs * sizeof(*gsl->entries));
+	if (!gsl)
+		return op_support;
+
+	rc = cxlmi_cmd_get_supported_logs(ep, NULL, gsl);
+	if (rc)
+		return op_support;
+
+	rc = parse_supported_logs(gsl, &cel_size);
+	if (rc)
+		return op_support;
+	else {
+		/* we know there is a CEL */
+		rc = support_opcode(ep, cel_size, opcode, &op_support);
+	}
+
+	free(gsl);
+	return op_support;
+}

--- a/examples/fmapi-mctp.c
+++ b/examples/fmapi-mctp.c
@@ -1,0 +1,505 @@
+#include <sys/wait.h>
+#include "examples.h"
+#define MAX_CHARS 50
+#define MAX_EXTENTS 10
+
+enum {
+    CREATE_DAX_DEVICE,
+    LIST_DAX_DEVICE,
+    ONLINE_DAX_DEVICE,
+    LSMEM,
+    NUM_CMDS
+};
+
+/* Hardcoded to use region0 and dax0.1 only. */
+static char *DAX_DEVICE_CMDS[] = {
+    [CREATE_DAX_DEVICE] = "daxctl create-device -r region0",
+    [LIST_DAX_DEVICE] = "daxctl list -r region0 -D",
+    [ONLINE_DAX_DEVICE] = "daxctl reconfigure-device dax0.1 -m system-ram",
+    [LSMEM] = "lsmem"
+};
+
+/*
+ * Prompts user for the number of extents they want to add/relase with a max.
+ * of 10. Prompts for each start/end DPA in MiB, keeping track of each one in
+ * ext_list.
+ * Returns the number of extents in ext_list. If user specifies invalid
+ * start or end DPA, immediately returns number of valid extents previously
+ * specified, if any.
+ *
+ * @param ext_list: used to fill out extent fields (length, start_dpa, etc.)
+ * @param add: used to print "add" or "release" when prompting users
+ * @returns: the number of extents user specified
+ */
+static int parse_extents(extent *ext_list, bool add)
+{
+    uint64_t num_extents;
+    char input[MAX_CHARS];
+    uint64_t start, end;
+    char err = '\0';
+    char *errp = &err;
+    int i;
+
+    memset(input, 0, MAX_CHARS);
+    printf("How many extents to %s? (max. %d) ",
+           add ? "add" : "release",
+           MAX_EXTENTS);
+
+    if (!fgets(input, MAX_CHARS, stdin)) {
+        printf("Enter a valid number of extents.\n");
+        return -1;
+    }
+
+    num_extents = strtol(input, NULL, 10);
+
+    if (!num_extents || num_extents > 10) {
+        printf("Enter a valid number of extents.\n");
+        return -1;
+    }
+
+    if (!ext_list) {
+        printf("Failed to allocate extent list\n");
+        return -1;
+    }
+
+    for (i = 1; i <= num_extents; i++) {
+        printf("Enter extent %d start-end in MB (ex: 0-128): ", i);
+
+        if (!fgets(input, MAX_CHARS, stdin)) {
+            printf("Invalid length.\n");
+            return i - 1;
+        }
+
+        /* Parse extent string */
+        char *split = strchr(input, '-');
+        if (!split) {
+            printf("Invalid length.\n");
+            return i - 1;
+        }
+        *split = '\0';
+        start = strtol(input, &errp, 10);
+        /*
+         * 0 is a valid start, so check *nptr is not '\0'
+         * and **endptr is '\0' to ensure string was valid
+         */
+        if (*input == '\0' || err != '\0') {
+            printf("Invalid extent start for extent %d.\n", i);
+            return i - 1;
+        }
+        /* 0 is not a valid end so only need to check that end != 0*/
+        end = strtol(split + 1, &errp, 10);
+        if (!end) {
+            printf("Invalid extent end for extent %d.\n", i);
+            return i - 1;
+        }
+
+        if (end - start == 0) {
+            printf("Start and end cannot be equal.\n");
+            return i - 1;
+        }
+
+        start *= MiB;
+        end *= MiB;
+
+        ext_list[i - 1].start_dpa =  start;
+        ext_list[i - 1].len = end - start;
+    }
+
+    return num_extents;
+}
+
+/*
+ * Creates and sends 0x5604 FM Initiate DC Add to the given endpoint using
+ * extents specified in ext_list.
+ *
+ * @param: num_extents - number of extents in ext_list
+ * @param: ext_list - list of extents to include in add request
+ * @param: ep - endpoint to send request through
+ */
+int send_add(int num_extents, extent *ext_list, struct cxlmi_endpoint *ep)
+{
+    struct cxlmi_cmd_fmapi_initiate_dc_add_req* add_req = NULL;
+    int i, rc;
+    uint64_t total_len = 0;
+
+    add_req = calloc(1, sizeof(*add_req) +
+                     num_extents * sizeof(add_req->extents[0]));
+
+    if (!add_req) {
+        free(ext_list);
+        return -1;
+    }
+
+    add_req->host_id = 0;
+    add_req->selection_policy = CXL_EXTENT_SELECTION_POLICY_PRESCRIPTIVE;
+    add_req->ext_count = num_extents;
+
+    for (i = 0; i < num_extents; i++) {
+        add_req->extents[i].start_dpa = ext_list[i].start_dpa;
+        add_req->extents[i].len = ext_list[i].len;
+        total_len += ext_list[i].len;
+    }
+
+    add_req->length = total_len;
+    printf("Sending add request for %i extents\n", num_extents);
+
+    rc = cxlmi_cmd_fmapi_initiate_dc_add(ep, NULL, add_req);
+    free(add_req);
+    return rc;
+}
+
+/*
+ * Creates and sends 0x5605 FM Initiate DC Release to the given endpoint using
+ * extents specified in ext_list.
+ *
+ * @param: num_extents - number of extents in ext_list
+ * @param: ext_list - list of extents to include in add request
+ * @param: ep - endpoint to send request through
+ */
+int send_release(int num_extents, extent *ext_list, struct cxlmi_endpoint *ep)
+{
+    struct cxlmi_cmd_fmapi_initiate_dc_release_req* release_req = NULL;
+    int i, rc;
+    uint64_t total_len = 0;
+
+    release_req = calloc(1, sizeof(*release_req) +
+        num_extents * sizeof(release_req->extents[0]));
+
+    if (!release_req) {
+        free(ext_list);
+        return -1;
+    }
+
+    release_req->host_id = 0;
+    release_req->flags = CXL_EXTENT_REMOVAL_POLICY_PRESCRIPTIVE;
+    release_req->ext_count = num_extents;
+
+    for (i = 0; i < num_extents; i++) {
+        release_req->extents[i].start_dpa = ext_list[i].start_dpa;
+        release_req->extents[i].len = ext_list[i].len;
+        total_len += ext_list[i].len;
+    }
+
+    release_req->length = total_len;
+    printf("Sending release request for %i extents\n", num_extents);
+
+    rc = cxlmi_cmd_fmapi_initiate_dc_release(ep, NULL, release_req);
+
+    free(release_req);
+    return rc;
+}
+
+/*
+ * Sends 0x5603 Get DC Region Extent Lists through the specified endpoint and
+ * returns the number of extents on the device through the input pointer
+ * num_extents. Prints extents info if parameter 'print' set to true
+ *
+ * @param: ep - endpoint to send request through
+ * @param: print - if true, prints extent info
+ * @returns: number of extents on the device or -1 if an error occurred
+ */
+static int get_extent_info(struct cxlmi_endpoint *ep, bool print)
+{
+    struct cxlmi_cmd_fmapi_get_dc_region_ext_list_req req;
+    struct cxlmi_cmd_fmapi_get_dc_region_ext_list_rsp *rsp;
+    int i, rc;
+
+    req.host_id = 0;
+    req.extent_count = MAX_EXTENTS;
+    req.start_ext_index = 0;
+
+    rsp = calloc(1, sizeof(*rsp) + req.extent_count * sizeof(rsp->extents[0]));
+
+    if (!rsp) {
+        return -1;
+    }
+
+    rc = cxlmi_cmd_fmapi_get_dc_region_ext_list(ep, NULL, &req, rsp);
+    if (rc) {
+        rc = -1;
+        goto free_out;
+    }
+
+    if (print) {
+        printf("\tHost Id: %hu\n", rsp->host_id);
+        printf("\tStarting Extent Index: %u\n", rsp->start_ext_index);
+        printf("\tNumber of Extents Returned: %u\n", rsp->extents_returned);
+        printf("\tTotal Extents: %u\n", rsp->total_extents);
+        printf("\tExtent List Generation Number: %u\n",
+               rsp->list_generation_num);
+
+        for (i = 0; i < rsp->extents_returned; i++) {
+            printf("\t\tExtent %d Info:\n", i);
+            printf("\t\t\tStart DPA: 0x%08lx\n", rsp->extents[i].start_dpa);
+            printf("\t\t\tLength: 0x%08lx\n", rsp->extents[i].len);
+        }
+    }
+    rc = rsp->total_extents;
+
+free_out:
+    free(rsp);
+    return rc;
+}
+
+/* Frees all endpoints for the given context and the context itself */
+static void cleanup_ctx(struct cxlmi_ctx *ctx)
+{
+    struct cxlmi_endpoint *ep, *tmp;
+    cxlmi_for_each_endpoint_safe(ctx, ep, tmp) {
+        cxlmi_close(ep);
+    }
+    cxlmi_free_ctx(ctx);
+}
+
+/*
+ * Splits input cmd into X tokens, using ' ' as the delimiter. Allocates space
+ * for each token. Allocated space must be freed by the caller. Returns number
+ * of tokens input cmd was split into.
+ *
+ * @param: cmd - a string to split using ' ' as the delimiter
+ * @param: argv - null-terminated arr to store the tokens that cmd is split into
+ * @returns: num tokens that cmd is split into (number of elements in argv - 1)
+ */
+static int split_cmd_to_argv(char* cmd, char*** argvp)
+{
+    char** argv;
+    char* cmd_cpy = strdup(cmd);
+    char* tok = strtok(cmd_cpy, " ");
+    int i, argc = 0;
+
+    while (tok != NULL) {
+        tok = strtok(NULL, " ");
+        argc++;
+    }
+    free(cmd_cpy);
+
+    argv = calloc(argc + 1, sizeof(argv[0]));
+    if (!argv) {
+        printf("Failed to allocate argv\n");
+        return -1;
+    }
+
+    cmd_cpy = strdup(cmd);
+    tok = strtok(cmd_cpy, " ");
+    argc = 0;
+    while (tok != NULL) {
+        argv[argc] = calloc(1, strlen(tok) + 1);
+
+        if (!argv[argc]) {
+            printf("Failed to allocate argv.\n");
+            for (i = 0; i < argc; i++) {
+                free(argv[argc]);
+            }
+            free(argv);
+            return -1;
+        }
+
+        strcpy(argv[argc], tok);
+        tok = strtok(NULL, " ");
+        argc++;
+    }
+
+    argv[argc] = NULL;
+    free(cmd_cpy);
+    *argvp = argv;
+    return argc;
+}
+
+/*
+ * Parent proc forks and waits on child proc to execvp() the given file with
+ * the given argv.
+ *
+ * @param: file - file for execvp()
+ * @param: argv - arguments for execvp()
+ * @param: rc - return code to store error info in
+ */
+static void execute_cmd(char* file, char** argv, int *rc)
+{
+    int pid = fork();
+
+    if (pid < 0) {
+        printf("Fork failed\n");
+        exit(-1);
+    }
+
+    if (pid == 0) {
+        if (execvp(file, argv)) {
+            exit(-1);
+        }
+    } else {
+        int status;
+        wait(&status);
+        if (!WIFEXITED(status)) {
+            *rc = -1;
+            return;
+        }
+        *rc = WEXITSTATUS(status);
+    }
+}
+
+/*
+ * Return true if user input == 'y'. Defaults to yes if nothing is entered.
+ * False otherwise.
+ * @param: buf - user input buf
+ * @param: rc - pointer through which to return error codes
+ */
+static bool input_is_yes(char* buf, int *rc)
+{
+    if (!fgets(buf, MAX_CHARS, stdin)) {
+        printf("Invalid input. Aborting\n");
+        *rc = -1;
+        return false;
+    }
+
+    return buf[0] == 'y' || buf[0] == '\n';
+}
+
+/*
+ * Prompts user to create DAX device. Defaults to 'y' if nothing entered.
+ * If 'y', create and online a DAX Device by executing the commands defined in
+ * DAX_DEVICE_CMDS.
+ * The commands are parsed into an argv and executed by a child proc via
+ * fork() and exec().
+ *
+ * @return: -1 if executing a command failed. 0 otherwise.
+ */
+static int create_dax_device(void) {
+    char buf[MAX_CHARS] = {0};
+    char** argv = NULL;
+    int i, j, rc, argc;
+
+    printf("Create DAX Device for this region? [y/n] ");
+    if (input_is_yes(buf, &rc)) {
+        for (i = 0; i < NUM_CMDS; i++) {
+            memset(buf, 0, MAX_CHARS);
+            argv = NULL;
+            printf("%s\n", DAX_DEVICE_CMDS[i]);
+
+            argc = split_cmd_to_argv(DAX_DEVICE_CMDS[i], &argv);
+
+            if (argc < 0) {
+                printf("Failed to split command\n");
+                return -1;
+            }
+
+            execute_cmd(argv[0], argv, &rc);
+
+            for (j = 0; j < argc; j++) {
+                free(argv[j]);
+            }
+            free(argv);
+
+            if (rc) {
+                return rc;
+            }
+
+            if (i < NUM_CMDS - 1) {
+                printf("Next cmd: '%s' ------------- continue? [y/n] ",
+                       DAX_DEVICE_CMDS[i + 1]);
+                if (!input_is_yes(buf, &rc)) {
+                    break;
+                }
+            }
+        }
+    } else {
+        printf("Skipping DAX Device creation for this region.\n");
+    }
+    return rc;
+}
+
+int main(int argc, char **argv)
+{
+    struct cxlmi_ctx *ctx;
+    struct cxlmi_endpoint *ep, *tmp;
+    extent *ext_list = calloc(MAX_EXTENTS, sizeof(extent));
+    char buf[MAX_CHARS];
+    uint8_t cmd;
+    int rc = 0, num_extents;
+
+    ctx = cxlmi_new_ctx(stdout, DEFAULT_LOGLEVEL);
+    if (!ctx) {
+        fprintf(stderr, "cannot create new context object\n");
+        return EXIT_FAILURE;
+    }
+
+    if (argc == 1) {
+        int num_ep = cxlmi_scan_mctp(ctx);
+
+        printf("scanning dbus...\n");
+
+        if (num_ep < 0) {
+            fprintf(stderr, "dbus scan error\n");
+            rc = -1;
+            goto exit_free_ctx;
+        } else if (num_ep == 0) {
+            printf("no endpoints found\n");
+            rc = -1;
+            goto exit_free_ctx;
+        } else
+            printf("found %d endpoint(s)\n", num_ep);
+    } else if (argc == 3) {
+        unsigned int nid;
+        uint8_t eid;
+
+        nid = strtol(argv[1], NULL, 10);
+        eid = strtol(argv[2], NULL, 10);
+        printf("ep %d:%d\n", nid, eid);
+
+        ep = cxlmi_open_mctp(ctx, nid, eid);
+        if (!ep) {
+            fprintf(stderr, "cannot open MCTP endpoint %d:%d\n", nid, eid);
+            rc = -1;
+            goto exit_free_ctx;
+        }
+    } else {
+        fprintf(stderr, "must provide MCTP endpoint nid:eid touple\n");
+        rc = -1;
+        goto exit_free_ctx;
+    }
+
+    cxlmi_for_each_endpoint_safe(ctx, ep, tmp) {
+        if (ep_supports_op(ep, 0x5600)) {
+            while (true) {
+                memset(buf, 0, MAX_CHARS);
+                memset(ext_list, 0, sizeof(extent) * MAX_EXTENTS);
+                printf("Enter 1 (add), 2 (release), 3 (print). Otherwise, exit: ");
+                if (!fgets(buf, MAX_CHARS, stdin)) {
+                    goto create_dax_device;
+                }
+                cmd = strtol(buf, NULL, 10);
+                if (!cmd) {
+                    goto create_dax_device;
+                }
+
+                switch (cmd) {
+                    case 1:
+                        num_extents = parse_extents(ext_list, 1);
+                        if (num_extents > 0) {
+                            rc = send_add(num_extents, ext_list, ep);
+                        }
+                        break;
+                    case 2:
+                        num_extents = parse_extents(ext_list, 0);
+                        if (num_extents > 0) {
+                            rc = send_release(num_extents, ext_list, ep);
+                        }
+                        break;
+                    case 3:
+                        rc = get_extent_info(ep, true);
+                        break;
+                }
+
+            }
+        }
+        cxlmi_close(ep);
+    }
+create_dax_device:
+    /* Create DAX Device if extents were added */
+    if (get_extent_info(ep, false) > 0) {
+        rc = create_dax_device();
+    }
+exit_free_ctx:
+    free(ext_list);
+    cleanup_ctx(ctx);
+    return rc;
+}

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -15,3 +15,10 @@ executable(
     dependencies: libcxlmi_dep,
     include_directories: [inc]
 )
+
+executable(
+    'fmapi-mctp',
+    ['fmapi-mctp.c'],
+    dependencies: libcxlmi_dep,
+    include_directories: [inc]
+)


### PR DESCRIPTION
This program prompts the user to add/release/print extents and sends the corresponding FM API command to the device. It opens MCTP endpoints automatically by scanning dbus if no arguments are provided. Otherwise, a valid MCTP NID:EID tuple must be provided.
If there are >0 extents when exiting, the user will be prompted to create a DAX Device for the region. The program executes `daxctl ...-r [region_id]` to do so. *The region id is currently hard-coded to region0

Example Output: Add 1 Extent
> Enter 1 (add), 2 (release), 3 (print). Otherwise, exit: 3
        Host Id: 0
        Starting Extent Index: 0
        Number of Extents Returned: 0
        Total Extents: 0
        Extent List Generation Number: 0
Enter 1 (add), 2 (release), 3 (print). Otherwise, exit: 1
How many extents to add? 1
Enter extent 1 start-end in MB (ex: 0-128): 0-128
Sending add request for 1 extents

Example Output: Print Extent
> Enter 1 (add), 2 (release), 3 (print). Otherwise, exit: 3
        Host Id: 0
        Starting Extent Index: 0
        Number of Extents Returned: 1
        Total Extents: 1
        Extent List Generation Number: 0
                Extent 0 Info:
                        Start DPA: 0x00000000
                        Length: 0x08000000

Example Output: Create DAX device:
> Enter 1 (add), 2 (release), 3 (print). Otherwise, exit: c
Create DAX Device for this region? [y/n] y
daxctl create-device -r region0
[
  {
    "chardev":"dax0.1",
    "size":134217728,
    "target_node":1,
    "align":2097152,
    "mode":"devdax"
  }
]
created 1 device
daxctl list -r region0 -D
[
  {
    "chardev":"dax0.1",
    "size":134217728,
    "target_node":1,
    "align":2097152,
    "mode":"devdax"
  }